### PR TITLE
fix box download

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,17 +4,15 @@
 Vagrant.configure("2") do |config|
 
   # Ubuntu Server 14.04 LTS
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "puppetlabs/ubuntu-14.04-64-puppet"
   config.vm.provision :shell, :inline => "apt-get update -y --fix-missing"
 
   # Ubuntu Server 12.04 LTS
-  # config.vm.box = "ubuntu_server_1204_x64"
-  # config.vm.box_url = "http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-12042-x64-vbox4210.box"
+  # config.vm.box = "puppetlabs/ubuntu-12.04-64-puppet"
   # config.vm.provision :shell, :inline => "apt-get update -y --fix-missing"
 
-  # CentOS 6.4
-  #config.vm.box = "centos_64_x64"
-  #config.vm.box_url = "http://puppet-vagrant-boxes.puppetlabs.com/centos-64-x64-vbox4210.box"
+  # CentOS 6.5
+  #config.vm.box = "puppetlabs/centos-6.5-64-puppet"
   #config.vm.provision :shell, :inline => "yum -y update"
 
   config.vm.provision :puppet do |puppet|


### PR DESCRIPTION
On `vagrant up` there is an error, when downloading box:

```
    production: Downloading: https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box
An error occurred while downloading the remote file. The error
message, if any, is reproduced below. Please fix this error and tryagain.

The requested URL returned error: 404 Not Found
```

I recommend you to use Vagrant's cloud storage: https://vagrantcloud.com/discover/featured
