### PR TITLE
Add diaspora:fixtures:generate_and_load task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 src
 capistrano/.capistrano
 capistrano/bin
+*~

--- a/capistrano/tasks/diaspora.cap
+++ b/capistrano/tasks/diaspora.cap
@@ -54,6 +54,23 @@ namespace :diaspora do
     after :start, :info
     after :restart, :info
   end
+
+  namespace :fixtures do
+    desc "Generates fixtures and load them to the database"
+    task :generate_and_load do
+      on roles(:app) do
+        within "#{current_path}" do
+          with rails_env: "test" do
+            execute :bundle, :exec, :rake, "db:drop db:create db:schema:load"
+          end
+          execute :bundle, :exec, :rake, "tests:generate_fixtures"
+          with rails_env: "#{fetch(:rails_env)}", FIXTURES_PATH: "spec/fixtures" do
+            execute :bundle, :exec, :rake, "db:fixtures:load"
+          end
+        end
+      end
+    end
+  end
 end
 
 namespace :load do


### PR DESCRIPTION
The ```diaspora:fixtures:generate_and_load``` task generates fixtures
within the test env using the [fixture builder from diaspora]
(https://github.com/diaspora/diaspora/blob/develop/spec/support/fixture_builder.rb)
and then loads them to the database. This can be used if you want
to do some manual testing and want to automatically seed the
database with some test data.